### PR TITLE
fix(ci): download NLTK punkt_tab for tokenizer

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,6 +24,14 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Cache NLTK data
+      uses: actions/cache@v4
+      with:
+        path: ~/nltk_data
+        key: ${{ runner.os }}-nltk-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-nltk-${{ matrix.python-version }}-
+          ${{ runner.os }}-nltk-
     - name: Install dependencies
       run: make install
     - name: Lint with flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ flask-sse
 selenium
 webdriver-manager
 validators
-nltk
+# Pin NLTK to stabilize tokenizer resources in CI
+nltk>=3.9,<4

--- a/src/search/tokenizer.py
+++ b/src/search/tokenizer.py
@@ -14,7 +14,11 @@ from nltk.tokenize import word_tokenize
 from nltk.stem import WordNetLemmatizer
 import string
 
+# NLTK 3.9 split tokenizer tables into a separate
+# resource named "punkt_tab". Download both for
+# compatibility across environments/CI.
 nltk.download("punkt", quiet=True)
+nltk.download("punkt_tab", quiet=True)
 nltk.download("stopwords", quiet=True)
 nltk.download("wordnet", quiet=True)
 


### PR DESCRIPTION
Summary
- Fix CI LookupError for NLTK 'punkt_tab' by downloading it alongside 'punkt' in the tokenizer.
- Add caching of NLTK data in GitHub Actions to speed up runs.
- Pin nltk to >=3.9,<4 to stabilize tokenizer resources across environments.

Changes
- src/search/tokenizer.py: add `nltk.download('punkt_tab', quiet=True)`
- .github/workflows/python-package.yml: add `actions/cache@v4` for `~/nltk_data`
- requirements.txt: pin `nltk>=3.9,<4`

Impact
- Behavior remains the same; ensures required tokenizer data is available and improves CI reliability/performance. No API changes.

Verification
- CI should pass on all matrix Python versions after cache warm-up.
- Local: `make install && make test` continues to pass.

Notes
- The first workflow run after merge will populate the NLTK cache; subsequent runs should be faster.
