### PR TITLE
Fix duplicate word in log reader comment

### DIFF
--- a/src/log_reader_cron.py
+++ b/src/log_reader_cron.py
@@ -40,6 +40,6 @@ if __name__ == "__main__":
     pkl_file_name = trie_storage.save(trie)
     logger.info(f"SubgraphCacheTrie saved to {pkl_file_name}")
 
-    # tell the server to pick up the the new trie
+    # tell the server to pick up the new trie
     status_code = notify_server("trie/load")
     logger.info(f"Server response for loading {pkl_file_name}: {status_code}")


### PR DESCRIPTION
## Summary
- correct comment in `log_reader_cron.py` to remove duplicated word

## Testing
- `pytest -q` *(fails: Unable to obtain driver for chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6897a31d2be88324b79fb5b9321ff386