### PR TITLE
Fix Node.url to strip query and fragment correctly

### DIFF
--- a/src/web_crawler/node.py
+++ b/src/web_crawler/node.py
@@ -26,8 +26,8 @@ class Node:
                 parsed_url.scheme,
                 parsed_url.netloc,
                 parsed_url.path,
-                parsed_url.query,
                 parsed_url.params,
+                "",  # No query
                 "",  # No fragment
             )
         )


### PR DESCRIPTION
## Summary
- Ensure Node.url reconstructs URLs without query or fragment

## Testing
- `pytest` *(fails: selenium.common.exceptions.NoSuchDriverException: Message: Unable to obtain driver for chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6897a31e793883248198e04be5c4b49f