### PR TITLE
Return logger from add_file_handler

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -9,6 +9,7 @@ def add_file_handler(logger: logging.Logger, filename: str) -> logging.Logger:
     formatter = logging.Formatter(LOG_FORMAT)
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
+    return logger
 
 
 def get_static_file(filename: str) -> str:


### PR DESCRIPTION
## Summary
- return the logger from add_file_handler for clarity

## Testing
- `make lint`
- `pytest` *(fails: selenium.common.exceptions.NoSuchDriverException: Message: Unable to obtain driver for chrome)*
- `pytest src/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a31f789c832497914cad3902d37d