### PR TITLE
Fix trie delete pruning and expand tests

### DIFF
--- a/src/autocomplete/tests/test_trie.py
+++ b/src/autocomplete/tests/test_trie.py
@@ -58,10 +58,12 @@ def test_delete():
     assert t.find("an").is_terminal is True
     # delete a leaf
     t.delete("all")
+    assert t.root["a"].child_keys() == {"n"}
     assert t.find("all") is None
     assert t.find("any").value == 2
     # delete an inner node
     t.delete("an")
+    assert t.root["a"]["n"].child_keys() == {"y"}
     assert t.find("an") is not None
     assert t.find("an").is_terminal is False
     # delete a non-existant key

--- a/src/autocomplete/trie.py
+++ b/src/autocomplete/trie.py
@@ -43,16 +43,20 @@ class Trie:
         return current_node
 
     def delete(self, key: str):
-        def inner(node, key) -> Node:
+        def inner(node, key) -> Optional[Node]:
             if key == "":
                 if node.is_terminal:
                     node.is_terminal = False
                     node.value = None
-                return node if len(node.children) > 0 else None
+                return node if node.children else None
             if key[0] not in node.children:
-                return None
-            node[key[0]] = inner(node[key[0]], key[1:])
-            return node
+                return node
+            child = inner(node[key[0]], key[1:])
+            if child is None:
+                del node.children[key[0]]
+            else:
+                node[key[0]] = child
+            return node if node.children or node.is_terminal else None
 
         inner(self.root, key)
 


### PR DESCRIPTION
## Summary
- assert child keys after deletions in trie tests
- prune empty nodes when deleting from the trie

## Testing
- `pytest src/autocomplete/tests/test_trie.py`
- `pytest` *(fails: NoSuchDriverException: Unable to obtain driver for chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6897a321a3288324a46465def07873e0