### PR TITLE
Don't just skip int test if we can't download model

### DIFF
--- a/src/search/tests/test_inverted_index.py
+++ b/src/search/tests/test_inverted_index.py
@@ -95,10 +95,7 @@ def test_top_k_cosine(inverted_index, node0, node1):
 
 
 def test_paraphrase_minilm_model_simple_example():
-    try:
-        model = SentenceTransformer("sentence-transformers/paraphrase-MiniLM-L3-v2")
-    except (requests.exceptions.RequestException, OSError) as e:
-        pytest.skip(f"requires model download: {e}")
+    model = SentenceTransformer("sentence-transformers/paraphrase-MiniLM-L3-v2")
 
     index = InvertedIndex(model=model)
 


### PR DESCRIPTION
The previous test would just skip if the model couldn't be downloaded.

If this works in CI, we should keep it since this is important functionality to test.